### PR TITLE
Make sure all build artifacts have correct file permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
         export LC_ALL=en_US.UTF-8
         bundle3.0
         jekyll build
+    - name: Change file permissions of build artifacts if necessary
+      run: |
+        chmod -c -R +rX "_site/" | while read line; do
+          echo "::warning title=Invalid file permissions automatically fixed::$line"
+        done
     - name: Upload the created pages artifact
       uses: actions/upload-pages-artifact@v1
       with:


### PR DESCRIPTION
The support for fixing file permissions has been removed in actions/upload-pages-artifact@v2. This is to prepare for the upgrade and to prevent permission errors in the future.