### PR TITLE
Fix CI: Pin build container to ubuntu:24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:latest
+      image: ubuntu:24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
         export LANG=en_US.UTF-8
         export LANGUAGE=en_US:en
         export LC_ALL=en_US.UTF-8
-        bundle3.0
+        bundle3.2
         jekyll build
     - name: Change file permissions of build artifacts if necessary
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:latest
+      image: ubuntu:24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -26,5 +26,5 @@ jobs:
         export LANG=en_US.UTF-8
         export LANGUAGE=en_US:en
         export LC_ALL=en_US.UTF-8
-        bundle3.0
+        bundle3.2
         jekyll build


### PR DESCRIPTION
Lately, `docker.io/ubuntu:latest` tag changed to Ubuntu `24.04` such that the `bundle3.0` invocation got outdated (since `24.04` has Ruby `3.2`).
Since we'd need the `bundle.X.Y` in sync with the system version, pin the container version too.