### PR TITLE
Disable fork artifact comment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
         path: "_site/"
 
   link:
+    if: $(( github.event.pull_request.head.repo.full_name == github.repository ))
     runs-on: ubuntu-latest
     needs: build # make sure the artifacts are uploaded first
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,7 @@
 name: Test
 
 on:
-  # NOTE: This uses pull_request_target so runs in the main repo's context.
-  #       Thus, permissions and code from main repo's branch are used.
-  #       E.g., changes to the workflow are only run on PRs from the main repo.
-  pull_request_target:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -15,12 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:24.04
-    permissions: {}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      permissions:
-        contents: read
     - name: Build
       run: |
         export DEBIAN_FRONTEND=noninteractive
@@ -39,8 +33,6 @@ jobs:
         jekyll build
 
     - uses: actions/upload-artifact@v4
-      permissions:
-        actions: write
       with:
         name: rendered-site
         path: "_site/"
@@ -49,8 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build # make sure the artifacts are uploaded first
     permissions:
-      actions: read # for reading artifacts
-      pull-requests: write # for commenting on your pr
+        contents: write # for commenting on your commit
+        pull-requests: write # for commenting on your pr
     steps:
       - uses: beni69/artifact-link@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:24.04
-    permissions:
-      contents: read
-      actions: write
+    permissions: {}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      permissions:
+        contents: read
     - name: Build
       run: |
         export DEBIAN_FRONTEND=noninteractive
@@ -39,6 +39,8 @@ jobs:
         jekyll build
 
     - uses: actions/upload-artifact@v4
+      permissions:
+        actions: write
       with:
         name: rendered-site
         path: "_site/"


### PR DESCRIPTION
Let's just skip commenting with the artifact link for now.
Needs figuring out actions permissions, i.e., we want the build and artifact upload run on forks' permissions but commenting needs upstream's permissions.
Could add a workflow triggered for finished checks later that inspects the artifacts similar to how we did that in, e.g., https://github.com/bioconda/bioconda-containers/blob/7b022b17af3f18619b629c1ee13df151c66b7fb8/images/bot/src/bioconda_bot/common.py .